### PR TITLE
Fix UTF8 compile error on Linux 

### DIFF
--- a/WorldWind/build.xml
+++ b/WorldWind/build.xml
@@ -49,6 +49,7 @@
                target="${worldwind.jdk.version}"
                fork="true"
                includeantruntime="false"
+               encoding="ISO-8859-1"
                memoryMaximumSize="512m">
             <classpath>
                 <pathelement location="jogl.jar"/>


### PR DESCRIPTION
Was producing javac error "unmappable character for encoding UTF8"
